### PR TITLE
Avoid default RewardScheme instance in step function

### DIFF
--- a/src/one_o_one/game.py
+++ b/src/one_o_one/game.py
@@ -232,10 +232,11 @@ class RewardScheme(NamedTuple):
 
 
 def step(
-    state: State, action: Action, reward_scheme: RewardScheme = RewardScheme()
+    state: State, action: Action, reward_scheme: RewardScheme | None = None
 ) -> tuple[State, float, bool, dict[str, int | str | int | None]]:
     s = state
     p = s.public
+    reward_scheme = reward_scheme or RewardScheme()
     me_idx = p.turn
     me = s.players[me_idx]
     used_card: Card | None = None


### PR DESCRIPTION
## Summary
- Allow passing a custom RewardScheme to `step` by defaulting the parameter to None
- Create a new RewardScheme inside `step` when one isn't provided

## Testing
- `env PYENV_VERSION=3.11.12 PYTHONPATH=src python -m pytest -q` *(fails: AttributeError: R1)*
- `env PYENV_VERSION=3.11.12 python -m ruff check src/one_o_one/game.py`
- `env PYENV_VERSION=3.11.12 PYTHONPATH=src python -m mypy src/one_o_one/game.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4286630f883318f67fc45cdf95ec0