### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy Game Replay
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rye
+        uses: eifinger/setup-rye@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: rye sync
+
+      - name: Generate game data
+        run: rye run python scripts/collect_data.py
+
+      - name: Generate replay HTML
+        run: rye run python scripts/spectate.py
+
+      - name: Prepare artifact
+        run: |
+          mkdir -p public/data
+          cp game_replay.html public/
+          cp data/game_data_for_spectate.json public/data/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- build game replay data and HTML after merging to main
- publish generated replay via GitHub Pages

## Testing
- `rye fmt --check` *(failed: command not found)*
- `rye lint` *(failed: command not found)*
- `rye run mypy .` *(failed: command not found)*
- `rye test` *(failed: command not found)*
- `PYENV_VERSION=3.11.12 python3 -m pytest` *(failed: ModuleNotFoundError: No module named 'one_o_one')*

------
https://chatgpt.com/codex/tasks/task_e_68c4488d511883318e057586d19ac19b