### PR TITLE
Fix player area initialization in game replay

### DIFF
--- a/game_replay.html
+++ b/game_replay.html
@@ -107,10 +107,10 @@
         const totalDisplay = document.getElementById('total-display');
         const penaltyDisplay = document.getElementById('penalty-display');
         const eventDisplay = document.getElementById('event-display');
-        const playerAreas = Array.from(
-            {0: 'p0', 1: 'p1', 2: 'p2', 3: 'p3'},
-            ([_, v]) => document.getElementById(v)
-        );
+        // Array.from でオブジェクトを渡していたため空配列となり、
+        // playerAreas[i] が undefined になるバグがあった。
+        // プレイヤーエリアの要素を確実に取得できるよう修正。
+        const playerAreas = Array.from({ length: 4 }, (_, i) => document.getElementById(`p${i}`));
 
         let currentTurn = 0;
 


### PR DESCRIPTION
## Summary
- Correct player area array construction in `game_replay.html`
- Added clarifying comments around player area setup

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4504345dc833188956a30fae51155