### PR TITLE
Add action mask helper for card game environment

### DIFF
--- a/src/one_o_one/game.py
+++ b/src/one_o_one/game.py
@@ -154,6 +154,22 @@ def legal_actions(state: State) -> tuple[Action, ...]:
     return tuple(actions)
 
 
+def action_mask(state: State) -> tuple[int, ...]:
+    """Return a binary mask of legal actions.
+
+    The tuple has an entry for every action in the :class:`Action` enum.  A
+    value of ``1`` indicates that the action is currently legal for the player
+    whose turn it is, while ``0`` marks an illegal action.  This utility is
+    particularly useful when integrating the environment with reinforcement
+    learning agents that expect a fixed-size action space with masking support.
+    """
+
+    mask = [0] * len(Action)
+    for a in legal_actions(state):
+        mask[int(a)] = 1
+    return tuple(mask)
+
+
 # ==== Card effect logic ====
 
 

--- a/tests/test_action_mask.py
+++ b/tests/test_action_mask.py
@@ -1,0 +1,59 @@
+from one_o_one.game import (
+    Action,
+    Card,
+    PlayerState,
+    PublicState,
+    Rank,
+    State,
+    action_mask,
+)
+
+
+def _mk_state(
+    *,
+    hand: tuple[Rank | None, Rank | None],
+    deck: tuple[Rank, ...],
+    turn: int = 0,
+    num_players: int = 2,
+) -> State:
+    """Construct a minimal ``State`` for mask testing."""
+
+    players = []
+    for i in range(num_players):
+        if i == turn:
+            h = (
+                Card(hand[0]) if hand[0] is not None else None,
+                Card(hand[1]) if hand[1] is not None else None,
+            )
+        else:
+            h = (Card(Rank.R4), Card(Rank.R5))
+        players.append(PlayerState(lp=10, hand=h))
+
+    public = PublicState(
+        turn=turn,
+        direction=1,
+        total=0,
+        penalty_level=1,
+        deck=tuple(Card(r) for r in deck),
+        discard=tuple(),
+        last_player=None,
+    )
+
+    alive = tuple(True for _ in range(num_players))
+    return State(players=tuple(players), public=public, alive=alive)
+
+
+def test_mask_allows_only_legal_actions() -> None:
+    state = _mk_state(hand=(Rank.R2, Rank.R3), deck=(Rank.R4,))
+    mask = action_mask(state)
+    assert mask == (1, 1, 1)
+
+    state = _mk_state(hand=(Rank.R2, None), deck=(Rank.R4,))
+    mask = action_mask(state)
+    assert mask[Action.PLAY_HAND_0] == 1
+    assert mask[Action.PLAY_HAND_1] == 0
+    assert mask[Action.PLAY_DECK] == 1
+
+    state = _mk_state(hand=(Rank.R2, None), deck=tuple())
+    mask = action_mask(state)
+    assert mask[Action.PLAY_DECK] == 0


### PR DESCRIPTION
## Summary
- add `action_mask` to expose legal action mask for reinforcement learning agents
- test mask covers hand and deck availability scenarios

## Testing
- `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c59bc831948331add3728087af6627