### PR TITLE
Fix player area initialization in spectate

### DIFF
--- a/game_replay.html
+++ b/game_replay.html
@@ -107,9 +107,12 @@
         const totalDisplay = document.getElementById('total-display');
         const penaltyDisplay = document.getElementById('penalty-display');
         const eventDisplay = document.getElementById('event-display');
+        // プレイヤー領域の取得
+        // Array.from にオブジェクトを渡すと空配列となるため、
+        // プレイヤー数に応じて DOM 要素を確実に取得する
         const playerAreas = Array.from(
-            {0: 'p0', 1: 'p1', 2: 'p2', 3: 'p3'},
-            ([_, v]) => document.getElementById(v)
+            { length: NUM_PLAYERS },
+            (_, i) => document.getElementById(`p${i}`)
         );
 
         let currentTurn = 0;

--- a/scripts/spectate.py
+++ b/scripts/spectate.py
@@ -135,9 +135,12 @@ HTML_TEMPLATE = """
         const totalDisplay = document.getElementById('total-display');
         const penaltyDisplay = document.getElementById('penalty-display');
         const eventDisplay = document.getElementById('event-display');
+        // プレイヤー領域の取得
+        // Array.from にオブジェクトを渡すと空配列となるため、
+        // プレイヤー数に応じて DOM 要素を確実に取得する
         const playerAreas = Array.from(
-            {{0: 'p0', 1: 'p1', 2: 'p2', 3: 'p3'}},
-            ([_, v]) => document.getElementById(v)
+            {{ length: NUM_PLAYERS }},
+            (_, i) => document.getElementById(`p${{i}}`)
         );
 
         let currentTurn = 0;


### PR DESCRIPTION
## Summary
- prevent undefined errors when rendering replay by correctly collecting player elements
- regenerate game_replay.html with fixed player element mapping

## Testing
- `uv run pytest`
- `uv run python scripts/spectate.py`


------
https://chatgpt.com/codex/tasks/task_e_68c79faa925c83319d4c00b045dd2f62